### PR TITLE
Removing FetchHearingData Functions on Server

### DIFF
--- a/src/lib/Dashboard/Debug.svelte
+++ b/src/lib/Dashboard/Debug.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { invalidateAll } from "$app/navigation";
 	import ErrorMessage from "$lib/ErrorMessage.svelte";
-	import { HearingDataOneEar, HearingScreening } from "$lib/interpret";
+	import { type HearingDataOneEar, type HearingScreening } from "$lib/interpret";
 	import type { HearingHistory } from "$lib/MyTypes";
     import { Button, ButtonGroup, Input, Label, Li, List } from "flowbite-svelte";
     import { getAllEmployeeHearingHistories, getEmployeeHearingHistory } from "$lib/client/postrequests"
@@ -23,13 +23,13 @@
         let historyFromServer: HearingHistory | undefined;
 
         try {
-            // getEmployeeHearingHistory() is found in serveraccessors.ts
+            // getEmployeeHearingHistory() is found in postrequests.ts
             historyFromServer = await getEmployeeHearingHistory(requestedID);
             success = true;  // set this to true to remove any previously showing errors
         }
         catch (error: any) {
             let errorMessage = error.message;
-            displayError(errorMessage ?? "An error occurred when modifying admin permissions");
+            displayError(errorMessage ?? "An error occurred when obtaining hearing history.");
         }
 
         // use the stored history to get whatever we need, like STS statuses and what not
@@ -49,13 +49,13 @@
         let historiesFromServer: HearingHistory[] = [];
 
         try {
-            // getAllEmployeeHearingHistories() is found in serveraccessors.ts
+            // getAllEmployeeHearingHistories() is found in postrequests.ts
             historiesFromServer = await getAllEmployeeHearingHistories(true);
             success = true;  // set this to true to remove any previously showing errors
         }
         catch (error: any) {
             let errorMessage = error.message;
-            displayError(errorMessage ?? "An error occurred when modifying admin permissions");
+            displayError(errorMessage ?? "An error occurred when obtaining hearing histories.");
         }
 
         // use the stored histories to get whatever we need, like STS statuses and what not

--- a/src/lib/EmployeesPage.svelte
+++ b/src/lib/EmployeesPage.svelte
@@ -124,6 +124,9 @@
         formData.append('employeeID', selectedEmployee.data.employeeID);
 
         // Fetch employee details from the server and years for other dropdown
+        // ! This function is doing way too much. 
+        // ! use getEmployeeHearingHistory() from postrequests.ts to condense all this into one function call
+        // ! See the Debug.svelte page for an example usage
         try {
             // Fetch employee information
             const dataResponse = await fetch('/dashboard?/fetchEmployeeInfo', {

--- a/src/lib/client/postrequests.ts
+++ b/src/lib/client/postrequests.ts
@@ -2,6 +2,7 @@
 // This will hold all the clientside server callers to avoid repetition.
 // Make sure each function returns a type. Use try and catch when calling these to avoid unhandled errors.
 
+import type { HearingScreening } from "$lib/interpret";
 import type { HearingHistory } from "../MyTypes";
 
 // GETTERS
@@ -59,6 +60,30 @@ export async function getAllEmployeeHearingHistories(omitInactive: boolean): Pro
     if (!result["success"]) throw Error(result["message"] ?? "Failed to extract all employee hearing histories (missing message).");
 
     return result["histories"];
+}
+
+export async function getEmployeeHearingScreening(employeeID: string, year: string): Promise<HearingScreening> {
+    // create form data and populate it with the necessary fields
+    const formData = new FormData();
+    formData.append('employeeID', employeeID);
+    formData.append('year', year);
+
+    const response = await fetch('/dashboard?/extractEmployeeHearingScreening', {
+        method: 'POST',
+        body: formData,
+    });
+
+    // intepret the response as JSON
+    const serverResponse = await response.json();
+
+    const result = JSON.parse(JSON.parse(serverResponse.data)[0]);
+    
+    // extractEmployeeHearingScreening() on the server will return both a success: boolean = true and screening: HearingScreening if it works
+    // otherwise, it will return success: boolean = false and message: string
+    
+    if (!result["success"]) throw Error(result["message"] ?? "Failed to extract the hearing screening (missing message).");
+
+    return result["screening"];
 }
 
 // SETTERS

--- a/src/lib/interpret.ts
+++ b/src/lib/interpret.ts
@@ -34,60 +34,51 @@ export enum AnomalyStatus {
     CNT = 8
 }
 
-class EarAnomalyStatus {
+export type EarAnomalyStatus = {
     leftStatus: AnomalyStatus;
     rightStatus: AnomalyStatus;
     reportYear: number;
     leftBaselineYear: number;
     rightBaselineYear: number;
+};
 
-    constructor(leftStatus: AnomalyStatus, rightStatus: AnomalyStatus, reportYear: number, leftBaselineYear: number, rightBaselineYear: number) {
-        this.leftStatus = leftStatus;
-        this.rightStatus = rightStatus;
-        this.reportYear = reportYear;
-        this.leftBaselineYear = leftBaselineYear;
-        this.rightBaselineYear = rightBaselineYear;
-    }
-}
-
-export class HearingDataOneEar {
+export type HearingDataOneEar = {
     hz500: number | null;
     hz1000: number | null;
     hz2000: number | null;
     hz3000: number | null;
     hz4000: number | null;
     hz6000: number | null;
-    hz8000: number | null
+    hz8000: number | null;
+};
 
-    constructor(hz500: number | null, 
-        hz1000: number | null, 
-        hz2000: number | null, 
-        hz3000: number | null, 
-        hz4000: number | null, 
-        hz6000: number | null, 
-        hz8000: number | null
-    ) {
-        this.hz500 = hz500;
-        this.hz1000 = hz1000;
-        this.hz2000 = hz2000;
-        this.hz3000 = hz3000;
-        this.hz4000 = hz4000;
-        this.hz6000 = hz6000;
-        this.hz8000 = hz8000;
+export type HearingDataOneEarString = {
+    hz500: string;
+    hz1000: string;
+    hz2000: string;
+    hz3000: string;
+    hz4000: string;
+    hz6000: string;
+    hz8000: string;
+};
+
+export function convertHearingDataOneEarToStrings(data: HearingDataOneEar): HearingDataOneEarString {
+    return {
+        hz500: data.hz500?.toString() ?? "CNT",
+        hz1000: data.hz1000?.toString() ?? "CNT",
+        hz2000: data.hz2000?.toString() ?? "CNT",
+        hz3000: data.hz3000?.toString() ?? "CNT",
+        hz4000: data.hz4000?.toString() ?? "CNT",
+        hz6000: data.hz6000?.toString() ?? "CNT",
+        hz8000: data.hz8000?.toString() ?? "CNT"
     }
 }
 
-export class HearingScreening {
+export type HearingScreening = {
     year: number;
     leftEar: HearingDataOneEar;
     rightEar: HearingDataOneEar;
-
-    constructor(year: number, leftEar: HearingDataOneEar, rightEar: HearingDataOneEar) {
-        this.year = year;
-        this.leftEar = leftEar;
-        this.rightEar = rightEar;
-    }
-}
+};
 
 export class UserHearingScreeningHistory {
     age: number;
@@ -199,13 +190,13 @@ export class UserHearingScreeningHistory {
         }
         if (arrayLength == 1) {
             // Only one screening, so it's the baseline with no comparison
-            return [new EarAnomalyStatus(
-                AnomalyStatus.Baseline, 
-                AnomalyStatus.Baseline, 
-                this.screenings[0].year, 
-                this.screenings[0].year, 
-                this.screenings[0].year
-            )];
+            return [{
+                leftStatus: AnomalyStatus.Baseline,
+                rightStatus: AnomalyStatus.Baseline,
+                reportYear: this.screenings[0].year,
+                leftBaselineYear: this.screenings[0].year,
+                rightBaselineYear: this.screenings[0].year,
+            } as EarAnomalyStatus];
         }
 
         let reportArray: EarAnomalyStatus[] = [];
@@ -221,7 +212,13 @@ export class UserHearingScreeningHistory {
         bestRightEarAverage = this.GetAverageHertzForSTSRangeForOneEar(this.screenings[0].rightEar);
 
         // push base status for the first hearing screening
-        reportArray.push(new EarAnomalyStatus(AnomalyStatus.Baseline, AnomalyStatus.Baseline, this.screenings[0].year, this.screenings[0].year, this.screenings[0].year));
+        reportArray.push({
+            leftStatus: AnomalyStatus.Baseline,
+            rightStatus: AnomalyStatus.Baseline,
+            reportYear: this.screenings[0].year,
+            leftBaselineYear: this.screenings[0].year,
+            rightBaselineYear: this.screenings[0].year,
+        } as EarAnomalyStatus);
 
         for (var i = 1; i < arrayLength; i++) {
             let previousScreening: HearingScreening = this.screenings[i - 1];
@@ -250,7 +247,13 @@ export class UserHearingScreeningHistory {
             let leftAnomalyStatus = this.GetStatusForEar(baselineLeftScreening.leftEar, previousScreening.leftEar, afterScreening.leftEar, ageCorrectionLeft);
             let rightAnomalyStatus = this.GetStatusForEar(baselineRightScreening.rightEar, previousScreening.rightEar, afterScreening.rightEar, ageCorrectionRight);
 
-            let currentAnomalyStatuses = new EarAnomalyStatus(leftAnomalyStatus, rightAnomalyStatus, afterScreening.year, bestLeftEarYear, bestRightEarYear);
+            let currentAnomalyStatuses = {
+                leftStatus: leftAnomalyStatus,
+                rightStatus: rightAnomalyStatus,
+                reportYear: afterScreening.year,
+                leftBaselineYear: bestLeftEarYear,
+                rightBaselineYear: bestRightEarYear,
+            } as EarAnomalyStatus;
             reportArray.push(currentAnomalyStatuses);
 
             // update baselines after report has confirmed improvement (otherwise the new baseline will compare to itself for redefinition year) 
@@ -386,13 +389,4 @@ export class UserHearingScreeningHistory {
 
         return average;
     }
-}
-
-// ! this is a duplicate of hearing screening, remove one of them
-interface HearingDataEntry {
-    year: number;
-    left: { hz500: number; hz1000: number; hz2000: number; hz3000: number; hz4000: number; hz6000: number; hz8000: number };
-    right: { hz500: number; hz1000: number; hz2000: number; hz3000: number; hz4000: number; hz6000: number; hz8000: number };
-}
-
-
+};

--- a/src/lib/server/actionsemployees.ts
+++ b/src/lib/server/actionsemployees.ts
@@ -2,10 +2,10 @@
 // Contains server functions pertaining to employee actions
 
 import { sql } from '@vercel/postgres';
-import { UserHearingScreeningHistory, HearingScreening, HearingDataOneEar, PersonSex } from "$lib/interpret";
+import { UserHearingScreeningHistory, type HearingScreening, type HearingDataOneEar, PersonSex } from "$lib/interpret";
 import { getHearingDataFromDatabaseRow } from '$lib/utility';
 import type { EmployeeInfo, HearingDataSingle, HearingHistory } from '$lib/MyTypes';
-import { checkEmployeeExists, extractEmployeeHearingHistoryFromDatabase, extractEmployeeHearingScreeningsFromDatabase, extractEmployeeInfoFromDatabase, extractEmployeeInfosFromDatabase } from './databasefunctions';
+import { checkEmployeeExists, extractEmployeeHearingHistoryFromDatabase, extractEmployeeHearingScreeningFromDatabase, extractEmployeeHearingScreeningsFromDatabase, extractEmployeeInfoFromDatabase, extractEmployeeInfosFromDatabase } from './databasefunctions';
 
 /**
  * @deprecated use extractEmployeeHearingScreenings() or extractEmployeeHearingHistory() instead
@@ -136,125 +136,6 @@ export async function extractEmployeeInfos(request: Request) {
             + (error.message ?? "no error message provided by server");
         console.error(errorMessage);
         return { success: false, message: errorMessage };
-    }
-}
-
-/**
- * @deprecated use extractEmployeeHearingScreenings() or extractEmployeeHearingHistory() instead
- */
-export async function fetchHearingData(request: Request) {
-    const formData = await request.formData();
-    const employeeID = formData.get('employeeID') as string;
-    const year = formData.get('year') as string;
-
-    try {
-        // Check if employee exists in database
-        const employeeIDQuery = await sql`SELECT employee_id FROM Employee WHERE employee_id = ${employeeID};`;
-        if (employeeIDQuery.rows.length === 0) {
-            throw new Error("User not found");
-        }
-        
-        // Get the oldest available year for the employee
-        const baselineYearQuery = await sql`
-            SELECT MIN(year) AS baseline_year
-            FROM Has
-            WHERE employee_id = ${employeeID};
-        `;
-        const baselineYear = baselineYearQuery.rows[0]?.baseline_year;
-
-        // Fetch hearing data for the baseline year
-        const baselineDataQuery = await sql`
-            SELECT d.Hz_500, d.Hz_1000, d.Hz_2000, d.Hz_3000, d.Hz_4000, d.Hz_6000, d.Hz_8000, h.ear
-            FROM Has h
-            JOIN Data d ON h.data_id = d.data_id
-            WHERE h.employee_id = ${employeeID} AND h.year = ${baselineYear};
-        `;
-
-        // Fetch hearing data for the new year
-        const newDataQuery = await sql`
-            SELECT d.Hz_500, d.Hz_1000, d.Hz_2000, d.Hz_3000, d.Hz_4000, d.Hz_6000, d.Hz_8000, h.ear
-            FROM Has h
-            JOIN Data d ON h.data_id = d.data_id
-            WHERE h.employee_id = ${employeeID} AND h.year = ${year};
-        `;
-
-        const baselineData = {
-            rightEar: baselineDataQuery.rows.filter(row => row.ear === 'right')[0] ?? null,
-            leftEar: baselineDataQuery.rows.filter(row => row.ear === 'left')[0] ?? null,
-        };
-
-        const newData = {
-            rightEar: newDataQuery.rows.filter(row => row.ear === 'right')[0] ?? null,
-            leftEar: newDataQuery.rows.filter(row => row.ear === 'left')[0] ?? null,
-        };
-
-        return JSON.stringify({
-            success: true,
-            hearingData: {
-                baselineYear,
-                newYear: year,
-                baselineData,
-                newData,
-            },
-        });
-    }
-    catch (error: any) {
-        const errorMessage = "Could not fetch hearing data: " 
-            + (error.message ?? "no error message provided by server");
-        console.error(errorMessage);
-        return JSON.stringify({ success: false, message: errorMessage });
-    }
-}
-
-/**
- * @deprecated use extractEmployeeHearingScreenings() or extractEmployeeHearingHistory() instead
- */
-export async function fetchHearingDataForYear(request: Request) {
-    const formData = await request.formData();
-    const employeeID = formData.get('employeeID') as string;
-    const year = formData.get('year') as string;
-
-    console.log(`EmployeeID: ${employeeID}, Year: ${year}`);
-
-    try {
-        // Fetch hearing data for the new year
-        const hearingDataQuery = await sql`
-            SELECT d.Hz_500, d.Hz_1000, d.Hz_2000, d.Hz_3000, d.Hz_4000, d.Hz_6000, d.Hz_8000, h.ear
-            FROM Has h
-            JOIN Data d ON h.data_id = d.data_id
-            WHERE h.employee_id = ${employeeID} AND h.year = ${year};
-        `;
-
-        const earData = {
-            rightEar: hearingDataQuery.rows.filter(row => row.ear === 'right')[0] ?? null,
-            leftEar: hearingDataQuery.rows.filter(row => row.ear === 'left')[0] ?? null,
-        };
-
-        if (!earData.rightEar && !earData.leftEar) {
-            const errorMessage = `There exists no hearing data for the year ${year}`;
-            console.error(errorMessage);
-            return JSON.stringify({ success: false, message: errorMessage });
-        }
-
-        const parsedLeftEar: HearingDataSingle = await getHearingDataFromDatabaseRow(earData.leftEar);
-        const parsedRightEar: HearingDataSingle = await getHearingDataFromDatabaseRow(earData.rightEar);
-
-        const dataReturn = {
-            success: true,
-            hearingData: {
-                year: year,
-                leftEar: parsedLeftEar,
-                rightEar: parsedRightEar
-            },
-        }
-
-        return JSON.stringify(dataReturn);
-    }
-    catch (error: any) {
-        const errorMessage = "Could not fetch hearing data: " 
-            + (error.message ?? "no error message provided by server");
-        console.error(errorMessage);
-        return JSON.stringify({ success: false, message: errorMessage });
     }
 }
 
@@ -505,21 +386,39 @@ export async function calculateSTS(request: Request) {
                 throw new Error(errorMessage);
             }
         });
-            
+        
         // Convert fetched data into HearingScreening objects
-        const screenings: HearingScreening[] = Object.entries(hearingDataByYear).map(([year, ears]) => 
-            new HearingScreening(
-                Number(year),
-                new HearingDataOneEar(
-                    ears.leftEar[0], ears.leftEar[1], ears.leftEar[2], ears.leftEar[3], 
-                    ears.leftEar[4], ears.leftEar[5], ears.leftEar[6]
-                ),
-                new HearingDataOneEar(
-                    ears.rightEar[0], ears.rightEar[1], ears.rightEar[2], ears.rightEar[3], 
-                    ears.rightEar[4], ears.rightEar[5], ears.rightEar[6]
-                )
-            )
-        );
+        const screenings: HearingScreening[] = Object.entries(hearingDataByYear).map(([year, ears]) => {
+            const leftEarData = ears.leftEar;
+            const rightEarData = ears.rightEar;
+
+            // Populate left and right ear hearing data
+            const leftEar: HearingDataOneEar = {
+                hz500: leftEarData[0] ?? null,
+                hz1000: leftEarData[1] ?? null,
+                hz2000: leftEarData[2] ?? null,
+                hz3000: leftEarData[3] ?? null,
+                hz4000: leftEarData[4] ?? null,
+                hz6000: leftEarData[5] ?? null,
+                hz8000: leftEarData[6] ?? null
+            };
+
+            const rightEar: HearingDataOneEar = {
+                hz500: rightEarData[0] ?? null,
+                hz1000: rightEarData[1] ?? null,
+                hz2000: rightEarData[2] ?? null,
+                hz3000: rightEarData[3] ?? null,
+                hz4000: rightEarData[4] ?? null,
+                hz6000: rightEarData[5] ?? null,
+                hz8000: rightEarData[6] ?? null
+            };
+
+            return {
+                year: Number(year),
+                leftEar,
+                rightEar
+            };
+        });
     
         console.log("SCREENINGS: ", screenings);
         
@@ -544,6 +443,29 @@ export async function calculateSTS(request: Request) {
     }
     catch (error: any) {
         const errorMessage = "Failed to calculate STS status: " 
+            + (error.message ?? "no error message provided by server");
+        console.error(errorMessage);
+        return JSON.stringify({ success: false, message: errorMessage });
+    }
+}
+
+export async function extractEmployeeHearingScreening(request: Request) {
+    const formData = await request.formData();
+    const employeeID = formData.get('employeeID') as string;
+    const year = formData.get('year') as string;
+    
+    try {
+        await checkEmployeeExists(employeeID); // will throw error if employee is not found
+        // Get employee hearing screenings from database
+        const screening: HearingScreening = await extractEmployeeHearingScreeningFromDatabase(employeeID, year);
+
+        return JSON.stringify({
+            success: true,
+            screening
+        });
+    } 
+    catch (error: any) {
+        const errorMessage = "Error in database when extracting employee hearing screenings: " 
             + (error.message ?? "no error message provided by server");
         console.error(errorMessage);
         return JSON.stringify({ success: false, message: errorMessage });

--- a/src/lib/server/databasefunctions.ts
+++ b/src/lib/server/databasefunctions.ts
@@ -4,7 +4,7 @@
 
 import { sql } from '@vercel/postgres';
 import { DatabaseError, type Admin, type Employee, type EmployeeInfo, type HearingHistory } from '../MyTypes';
-import { HearingDataOneEar, HearingScreening, PersonSex, UserHearingScreeningHistory } from '$lib/interpret';
+import { type HearingDataOneEar, type HearingScreening, PersonSex, UserHearingScreeningHistory } from '$lib/interpret';
 
 // EMPLOYEES
 /**
@@ -107,6 +107,88 @@ export async function extractEmployeeInfosFromDatabase(): Promise<EmployeeInfo[]
     return employeeInfos;
 }
 
+export async function extractEmployeeHearingScreeningFromDatabase(employeeID: string, year: string): Promise<HearingScreening> {
+    // this query will return 0 or 2 rows (left and right ears)
+    const query = await sql`
+        SELECT d.Hz_500, d.Hz_1000, d.Hz_2000, d.Hz_3000, d.Hz_4000, d.Hz_6000, d.Hz_8000, h.ear
+        FROM Has h
+        JOIN Data d ON h.data_id = d.data_id
+        WHERE h.employee_id = ${employeeID} AND h.year = ${year};
+    `;
+
+    if (query.rows.length === 0) {
+        throw new DatabaseError("Hearing data not found.");
+    }
+
+    const hearingDataByYear: Record<number, { leftEar: (number | null)[], rightEar: (number | null)[] }> = {};
+
+    query.rows.forEach(row => {
+        // Loop through each row of the query result to group data by year and
+        // store frequency thresholds for each ear separately
+        const yearKey = Number(row.year);
+        const earSide = row.ear.trim().toLowerCase();  // Normalize ear value
+    
+        if (!hearingDataByYear[yearKey]) {
+            hearingDataByYear[yearKey] = { leftEar: new Array(7).fill(0), rightEar: new Array(7).fill(0) };
+        }
+    
+        const frequencies = [
+            row.hz_500 === null ? null : Number(row.hz_500),
+            row.hz_1000 === null ? null : Number(row.hz_1000),
+            row.hz_2000 === null ? null : Number(row.hz_2000),
+            row.hz_3000 === null ? null : Number(row.hz_3000),
+            row.hz_4000 === null ? null : Number(row.hz_4000),
+            row.hz_6000 === null ? null : Number(row.hz_6000),
+            row.hz_8000 === null ? null : Number(row.hz_8000)
+        ];
+    
+        if (earSide === 'right') {
+            hearingDataByYear[yearKey].rightEar = frequencies;
+        } else if (earSide === 'left') {
+            hearingDataByYear[yearKey].leftEar = frequencies;
+        } else {
+            const errorMessage = `Unexpected ear side: ${row.ear}. Please contact the database administrator to fix the ear sides to either 'left' or 'right'`;
+            throw new Error(errorMessage);
+        }
+    });
+
+    const yearData = Object.entries(hearingDataByYear)[0]; // Get the first entry (or the only one)
+    const [obtainedYear, ears] = yearData;
+
+    const leftEarData = ears.leftEar;
+    const rightEarData = ears.rightEar;
+
+    // Populate left and right ear hearing data
+    const leftEar: HearingDataOneEar = {
+        hz500: leftEarData[0] ?? null,
+        hz1000: leftEarData[1] ?? null,
+        hz2000: leftEarData[2] ?? null,
+        hz3000: leftEarData[3] ?? null,
+        hz4000: leftEarData[4] ?? null,
+        hz6000: leftEarData[5] ?? null,
+        hz8000: leftEarData[6] ?? null
+    };
+
+    const rightEar: HearingDataOneEar = {
+        hz500: rightEarData[0] ?? null,
+        hz1000: rightEarData[1] ?? null,
+        hz2000: rightEarData[2] ?? null,
+        hz3000: rightEarData[3] ?? null,
+        hz4000: rightEarData[4] ?? null,
+        hz6000: rightEarData[5] ?? null,
+        hz8000: rightEarData[6] ?? null
+    };
+
+    // Convert fetched data into HearingScreening object
+    const screening: HearingScreening = {
+        year: Number(year),
+        leftEar,
+        rightEar
+    }
+
+    return screening;
+}
+
 export async function extractEmployeeHearingScreeningsFromDatabase(employeeID: string): Promise<HearingScreening[]> {
     const dataQuery = await sql`
         SELECT d.Hz_500, d.Hz_1000, d.Hz_2000, d.Hz_3000, d.Hz_4000, d.Hz_6000, d.Hz_8000, h.ear, h.year
@@ -154,19 +236,37 @@ export async function extractEmployeeHearingScreeningsFromDatabase(employeeID: s
     });
     
     // Convert fetched data into HearingScreening objects
-    const screenings: HearingScreening[] = Object.entries(hearingDataByYear).map(([year, ears]) => 
-        new HearingScreening(
-            Number(year),
-            new HearingDataOneEar(
-                ears.leftEar[0], ears.leftEar[1], ears.leftEar[2], ears.leftEar[3], 
-                ears.leftEar[4], ears.leftEar[5], ears.leftEar[6]
-            ),
-            new HearingDataOneEar(
-                ears.rightEar[0], ears.rightEar[1], ears.rightEar[2], ears.rightEar[3], 
-                ears.rightEar[4], ears.rightEar[5], ears.rightEar[6]
-            )
-        )
-    );
+    const screenings: HearingScreening[] = Object.entries(hearingDataByYear).map(([year, ears]) => {
+        const leftEarData = ears.leftEar;
+        const rightEarData = ears.rightEar;
+
+        // Populate left and right ear hearing data
+        const leftEar: HearingDataOneEar = {
+            hz500: leftEarData[0] ?? null,
+            hz1000: leftEarData[1] ?? null,
+            hz2000: leftEarData[2] ?? null,
+            hz3000: leftEarData[3] ?? null,
+            hz4000: leftEarData[4] ?? null,
+            hz6000: leftEarData[5] ?? null,
+            hz8000: leftEarData[6] ?? null
+        };
+
+        const rightEar: HearingDataOneEar = {
+            hz500: rightEarData[0] ?? null,
+            hz1000: rightEarData[1] ?? null,
+            hz2000: rightEarData[2] ?? null,
+            hz3000: rightEarData[3] ?? null,
+            hz4000: rightEarData[4] ?? null,
+            hz6000: rightEarData[5] ?? null,
+            hz8000: rightEarData[6] ?? null
+        };
+
+        return {
+            year: Number(year),
+            leftEar,
+            rightEar
+        };
+    });
 
     return screenings;
 }

--- a/src/lib/utility.ts
+++ b/src/lib/utility.ts
@@ -2,7 +2,7 @@ import type { Session } from "@auth/sveltekit";
 import { redirect, type RequestEvent, type Server, type ServerLoadEvent } from "@sveltejs/kit"
 import { sql, type QueryResult, type QueryResultRow } from "@vercel/postgres";
 import { PageCategory, type HearingDataSingle } from "./MyTypes";
-import { UserHearingScreeningHistory, HearingScreening, HearingDataOneEar, PersonSex, AnomalyStatus } from './interpret';
+import { UserHearingScreeningHistory, type HearingScreening, type HearingDataOneEar, PersonSex, AnomalyStatus } from './interpret';
 
 export function isNumber(value?: string | number): boolean {
     return ((value != null) &&
@@ -187,6 +187,7 @@ export function getPageCategory(page: string): PageCategory {
 
 // respects proper baselines
 export function calculateSTSClientSide(hearingData: any) {
+    // TODO: type hearing data (probably hearinghistory), which will remove the need to remap the hearingdata screenings
     if (!hearingData || !hearingData.screenings) {
         console.error("Invalid hearing data format");
         return [];
@@ -196,27 +197,35 @@ export function calculateSTSClientSide(hearingData: any) {
     const screenings = Object.entries(hearingData.screenings)
         .map(([year, data]) => {
             try {
-                return new HearingScreening(
-                    parseInt(year),
-                    new HearingDataOneEar(
-                        parseValueOrNull(data.left.hz500),
-                        parseValueOrNull(data.left.hz1000),
-                        parseValueOrNull(data.left.hz2000),
-                        parseValueOrNull(data.left.hz3000),
-                        parseValueOrNull(data.left.hz4000),
-                        parseValueOrNull(data.left.hz6000),
-                        parseValueOrNull(data.left.hz8000)
-                    ),
-                    new HearingDataOneEar(
-                        parseValueOrNull(data.right.hz500),
-                        parseValueOrNull(data.right.hz1000),
-                        parseValueOrNull(data.right.hz2000),
-                        parseValueOrNull(data.right.hz3000),
-                        parseValueOrNull(data.right.hz4000),
-                        parseValueOrNull(data.right.hz6000),
-                        parseValueOrNull(data.right.hz8000)
-                    )
-                );
+                const leftEarData = data.left;
+                const rightEarData = data.right;
+
+                // Populate left and right ear hearing data
+                const leftEar: HearingDataOneEar = {
+                    hz500: leftEarData["hz500"] ?? null,
+                    hz1000: leftEarData["hz1000"] ?? null,
+                    hz2000: leftEarData["hz2000"] ?? null,
+                    hz3000: leftEarData["hz3000"] ?? null,
+                    hz4000: leftEarData["hz4000"] ?? null,
+                    hz6000: leftEarData["hz6000"] ?? null,
+                    hz8000: leftEarData["hz8000"] ?? null
+                };
+
+                const rightEar: HearingDataOneEar = {
+                    hz500: rightEarData["hz500"] ?? null,
+                    hz1000: rightEarData["hz1000"] ?? null,
+                    hz2000: rightEarData["hz2000"] ?? null,
+                    hz3000: rightEarData["hz3000"] ?? null,
+                    hz4000: rightEarData["hz4000"] ?? null,
+                    hz6000: rightEarData["hz6000"] ?? null,
+                    hz8000: rightEarData["hz8000"] ?? null
+                };
+
+                return {
+                    year: Number(year),
+                    leftEar,
+                    rightEar
+                };
             } catch (err) {
                 console.error(`Error parsing screening data for year ${year}:`, err);
                 return null;

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -1,7 +1,7 @@
 import type { Actions, PageServerLoad } from './$types';
 import { turnAwayNonAdmins } from '$lib/utility';
 import { addHearingData, checkYearAvailability, modifyHearingData, fetchCalculateSTSData } from '$lib/server/actionshearingdata';
-import { fetchEmployeeInfo, fetchHearingData, fetchHearingDataForYear, fetchYears, modifyEmployeeDOB, modifyEmployeeEmail, modifyEmployeeName, modifyEmployeeStatus, modifyEmployeeSex, calculateSTS, extractEmployeeHearingScreenings, extractEmployeeInfo, extractEmployeeHearingHistory, extractAllEmployeeHearingHistories } from '$lib/server/actionsemployees';
+import { fetchEmployeeInfo, fetchYears, modifyEmployeeDOB, modifyEmployeeEmail, modifyEmployeeName, modifyEmployeeStatus, modifyEmployeeSex, calculateSTS, extractEmployeeHearingScreenings, extractEmployeeInfo, extractEmployeeHearingHistory, extractAllEmployeeHearingHistories, extractEmployeeHearingScreening } from '$lib/server/actionsemployees';
 import { addEmployee } from '$lib/server/actionsemployeeadd';
 import { deleteAdmins, modifyAdminName, modifyAdminPermissions } from '$lib/server/actionsadmins';
 import { extractAllEmployeeData, extractHearingData, extractBaselineHearingData, extractRecentHearingData } from '$lib/server/actionsmailing';
@@ -72,14 +72,6 @@ export const actions: Actions = {
     extractEmployeeInfo: async ({ request }) => {
         return extractEmployeeInfo(request);
     },
-    // ! to be removed later
-    fetchHearingData: async ({ request }) => {
-       return fetchHearingData(request);
-    },
-    // ! to be removed later
-    fetchHearingDataForYear: async ({ request }) => {
-        return fetchHearingDataForYear(request);
-     },
     modifyEmployeeName: async ({ request }) => {
         return modifyEmployeeName(request);
     },
@@ -98,6 +90,9 @@ export const actions: Actions = {
     // ! to be removed later
     calculateSTS: async ({ request }) => { 
         return calculateSTS(request);
+    },
+    extractEmployeeHearingScreening: async ({ request }) => {
+        return extractEmployeeHearingScreening(request);
     },
     extractEmployeeHearingScreenings: async ({ request }) => {
         return extractEmployeeHearingScreenings(request);


### PR DESCRIPTION
- `InsertDataPage.svelte` no longer uses deprecated `fetchHearingData()`
- Removed `fetchHearingData()` and `fetchHearingDataForYear()` as they are no longer in use
- Converted some classes with no methods that were being essentially used in `interpret.ts` to types
  - modified other files to accommodate this change